### PR TITLE
add the protocol in the href location

### DIFF
--- a/src/random.js
+++ b/src/random.js
@@ -4,4 +4,4 @@
 
 fetch('/members.json')
     .then((response) => response.json())
-    .then((json) => window.location.href = (json[parseInt(Math.random() * json.length)]).url);
+    .then((json) => window.location.href = "https://" + (json[parseInt(Math.random() * json.length)]).url);


### PR DESCRIPTION
Correct the `window.href.location` redirect by adding the `https://` protocol back into it. The protocol was initially in the  `members.json` and was removed. 